### PR TITLE
style: fix text-overflow for equally spaced

### DIFF
--- a/packages/styles/scss/components/progress-indicator/_progress-indicator.scss
+++ b/packages/styles/scss/components/progress-indicator/_progress-indicator.scss
@@ -76,6 +76,10 @@ $progress-indicator-bar-width: 1px inset transparent !default;
     border-radius: 50%;
     fill: $interactive;
   }
+  
+  .#{$prefix}--progress--space-equal .#{$prefix}--progress-text {
+    overflow: hidden;
+  }
 
   .#{$prefix}--progress-label {
     @include type-style('body-compact-01');


### PR DESCRIPTION
Closes #12121

I'm not certain this is the best solution, but thought it was a simple one that doesn't impact the default state styles.

#### Changelog

**New**

- N/A

**Changed**

- Adds `overflow: hidden` style to the wrapping progress text element for equally spaced progress indicators. The label now correctly shows the ellipsis on text overflow. 

**Removed**

- N/A

#### Testing / Reviewing

I tested the same changes in the [CodeSandbox](https://codesandbox.io/s/progressstep-text-overflow-8hsrih) from the issue. 
